### PR TITLE
Handle disabled replication nodes

### DIFF
--- a/pyravendb/connection/requests_factory.py
+++ b/pyravendb/connection/requests_factory.py
@@ -186,10 +186,7 @@ class HttpRequestsFactory(object):
         with open(topology_file, 'w+') as f:
             f.write(json.dumps(self.topology))
             self.replication_topology.queue.clear()
-            for destination in self.topology["Destinations"]:
-                self.replication_topology.put({"url": destination["Url"], "database": destination["Database"],
-                                               "credentials": {"api_key": destination["ApiKey"],
-                                                               "domain": destination["Domain"]}})
+            self.load_topology()
 
     def check_replication_change(self, topology_file):
 
@@ -220,14 +217,18 @@ class HttpRequestsFactory(object):
             try:
                 with open(topology_file, 'r') as f:
                     self.topology = json.loads(f.read())
-                    for destination in self.topology["Destinations"]:
-                        self.replication_topology.put({"url": destination["Url"], "database": destination["Database"],
-                                                       "credentials": {"api_key": destination["ApiKey"],
-                                                                       "domain": destination["Domain"]}})
+                    self.load_topology()
             except IOError:
                 pass
 
         self.check_replication_change(topology_file)
+
+    def load_topology(self):
+        for destination in self.topology["Destinations"]:
+            if not destination["Disabled"]:
+                self.replication_topology.put({"url": destination["Url"], "database": destination["Database"],
+                                               "credentials": {"api_key": destination["ApiKey"],
+                                                               "domain": destination["Domain"]}})
 
     def do_auth_request(self, api_key, oauth_source, second_api_key=None):
         api_name, secret = api_key.split('/', 1)

--- a/pyravendb/connection/requests_factory.py
+++ b/pyravendb/connection/requests_factory.py
@@ -225,7 +225,7 @@ class HttpRequestsFactory(object):
 
     def load_topology(self):
         for destination in self.topology["Destinations"]:
-            if not destination["Disabled"]:
+            if not destination["Disabled"] and not destination["IgnoredClient"]:
                 self.replication_topology.put({"url": destination["Url"], "database": destination["Database"],
                                                "credentials": {"api_key": destination["ApiKey"],
                                                                "domain": destination["Domain"]}})


### PR DESCRIPTION
When a replication node is disabled, it should not be queried against lol

Matches the JVM implementation.
https://github.com/ravendb/jvm-client/blob/efa16399973ae349eec8da987046c72a2079d2ae/Raven.Client.Java/src/main/java/net/ravendb/client/connection/ReplicationInformer.java#L139